### PR TITLE
Replace absolute wallbox path with model path

### DIFF
--- a/worlds/neo_workshop.sdf
+++ b/worlds/neo_workshop.sdf
@@ -452,7 +452,7 @@
         <visual name='visual'>
           <geometry>
             <mesh>
-              <uri>file:///home/pradheep/jazzy_ws/src/neo_gz_worlds/models/neo_wall_box/meshes/wallbox.dae</uri>
+              <uri>model://neo_wall_box/meshes/wallbox.dae</uri>
             </mesh>
           </geometry>
         </visual>


### PR DESCRIPTION
The neo workshop world currently contains an absolute path for the wallbox mesh, preventing the world from loading correctly. I replaced it with the model path, as used for the other meshes.